### PR TITLE
cleanup json files

### DIFF
--- a/matches/azul/20200607-A.json
+++ b/matches/azul/20200607-A.json
@@ -4,12 +4,7 @@
   "updatedAt": "2020-06-08T02:00:00.000Z",
   "description": "Played on Tabletop Simulator, standard board",
   "game": "azul",
-  "players": [
-    { "id": "ken" },
-    { "id": "matt" },
-    { "id": "eric" },
-    { "id": "aaron" }
-  ],
+  "players": ["ken", "matt", "eric", "aaron"],
   "results": [
     { "player": "matt", "score": 66 },
     { "player": "ken", "score": 65 },

--- a/matches/azul/20200607-B.json
+++ b/matches/azul/20200607-B.json
@@ -4,14 +4,9 @@
   "updatedAt": "2020-06-08T03:00:00.000Z",
   "description": "Played on Tabletop Simulator, grey board",
   "game": "azul",
-  "players": [
-    { "id": "matt" },
-    { "id": "eric" },
-    { "id": "aaron" },
-    { "id": "ken" }
-  ],
+  "players": ["matt", "eric", "aaron", "ken"],
   "results": [
-    { "player": "ken", "score": 94}, 
+    { "player": "ken", "score": 94 },
     { "player": "aaron", "score": 92 },
     { "player": "matt", "score": 69 },
     { "player": "eric", "score": 38 }

--- a/matches/tmars/20200610.json
+++ b/matches/tmars/20200610.json
@@ -5,43 +5,12 @@
   "location": "TTS",
   "description": "Matt's Birthday Game",
   "game": "tmars",
-  "players": [
-    {
-      "id": "adam"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "matt"
-    },
-    {
-      "id": "eric"
-    }
-  ],
+  "players": ["adam", "ken", "aaron", "matt", "eric"],
   "results": [
-    {
-      "player": "eric",
-      "score": 62
-    },
-    {
-      "player": "matt",
-      "score": 57
-    },
-    {
-      "player": "aaron",
-      "score": 56
-    },
-    {
-      "player": "adam",
-      "score": 55
-    },
-    {
-      "player": "ken",
-      "score": 51
-    }
+    { "player": "eric", "score": 62 },
+    { "player": "matt", "score": 57 },
+    { "player": "aaron", "score": 56 },
+    { "player": "adam", "score": 55 },
+    { "player": "ken", "score": 51 }
   ]
 }

--- a/matches/tta/179245.json
+++ b/matches/tta/179245.json
@@ -4,22 +4,9 @@
   "updatedAt": "2013-04-04T22:05:00.000Z",
   "description": "test game",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "134"
-    },
-    {
-      "player": "ken",
-      "score": "110"
-    }
+    { "player": "phil", "score": "134" },
+    { "player": "ken", "score": "110" }
   ]
 }

--- a/matches/tta/179487.json
+++ b/matches/tta/179487.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-04-06T12:05:00.000Z",
   "description": "Aaron Dixon's Game",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "121"
-    },
-    {
-      "player": "phil",
-      "score": "113"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "aaron", "score": "121" },
+    { "player": "phil", "score": "113" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/180456.json
+++ b/matches/tta/180456.json
@@ -4,22 +4,9 @@
   "updatedAt": "2013-04-05T02:20:00.000Z",
   "description": "secnod game",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "149"
-    },
-    {
-      "player": "ken",
-      "score": "122"
-    }
+    { "player": "phil", "score": "149" },
+    { "player": "ken", "score": "122" }
   ]
 }

--- a/matches/tta/181227.json
+++ b/matches/tta/181227.json
@@ -4,22 +4,9 @@
   "updatedAt": "2013-04-08T01:31:00.000Z",
   "description": "PHILIHP BUSBY's Game",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "107"
-    },
-    {
-      "player": "phil",
-      "score": "70"
-    }
+    { "player": "ken", "score": "107" },
+    { "player": "phil", "score": "70" }
   ]
 }

--- a/matches/tta/187906.json
+++ b/matches/tta/187906.json
@@ -4,36 +4,11 @@
   "updatedAt": "2013-05-13T18:31:00.000Z",
   "description": "we require more vesphene gas",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "sean"
-    }
-  ],
+  "players": ["phil", "ken", "aaron", "sean"],
   "results": [
-    {
-      "player": "phil",
-      "score": "242"
-    },
-    {
-      "player": "ken",
-      "score": "153"
-    },
-    {
-      "player": "aaron",
-      "score": "104"
-    },
-    {
-      "player": "sean",
-      "score": "-"
-    }
+    { "player": "phil", "score": "242" },
+    { "player": "ken", "score": "153" },
+    { "player": "aaron", "score": "104" },
+    { "player": "sean", "score": "-" }
   ]
 }

--- a/matches/tta/190753.json
+++ b/matches/tta/190753.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-05-13T00:37:00.000Z",
   "description": "slow ass bitches",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "155"
-    },
-    {
-      "player": "phil",
-      "score": "145"
-    },
-    {
-      "player": "aaron",
-      "score": "98"
-    }
+    { "player": "ken", "score": "155" },
+    { "player": "phil", "score": "145" },
+    { "player": "aaron", "score": "98" }
   ]
 }

--- a/matches/tta/191763.json
+++ b/matches/tta/191763.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-05-15T22:52:00.000Z",
   "description": "slow ass bitches (2)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "135"
-    },
-    {
-      "player": "phil",
-      "score": "115"
-    },
-    {
-      "player": "aaron",
-      "score": "88"
-    }
+    { "player": "ken", "score": "135" },
+    { "player": "phil", "score": "115" },
+    { "player": "aaron", "score": "88" }
   ]
 }

--- a/matches/tta/192497.json
+++ b/matches/tta/192497.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-05-18T11:43:00.000Z",
   "description": "glhf nr15",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "145"
-    },
-    {
-      "player": "phil",
-      "score": "108"
-    },
-    {
-      "player": "aaron",
-      "score": "78"
-    }
+    { "player": "ken", "score": "145" },
+    { "player": "phil", "score": "108" },
+    { "player": "aaron", "score": "78" }
   ]
 }

--- a/matches/tta/192736.json
+++ b/matches/tta/192736.json
@@ -4,36 +4,11 @@
   "updatedAt": "2013-06-01T14:45:00.000Z",
   "description": "we require more vesphene gas (3)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "sean"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "sean", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "235"
-    },
-    {
-      "player": "sean",
-      "score": "150"
-    },
-    {
-      "player": "phil",
-      "score": "115"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "235" },
+    { "player": "sean", "score": "150" },
+    { "player": "phil", "score": "115" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/192863.json
+++ b/matches/tta/192863.json
@@ -4,22 +4,9 @@
   "updatedAt": "2013-05-27T23:54:00.000Z",
   "description": "Test Game",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "117"
-    },
-    {
-      "player": "ken",
-      "score": "113"
-    }
+    { "player": "phil", "score": "117" },
+    { "player": "ken", "score": "113" }
   ]
 }

--- a/matches/tta/193314.json
+++ b/matches/tta/193314.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-05-23T23:50:00.000Z",
   "description": "slow ass bitches (3)",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "141"
-    },
-    {
-      "player": "ken",
-      "score": "135"
-    },
-    {
-      "player": "aaron",
-      "score": "115"
-    }
+    { "player": "phil", "score": "141" },
+    { "player": "ken", "score": "135" },
+    { "player": "aaron", "score": "115" }
   ]
 }

--- a/matches/tta/193868.json
+++ b/matches/tta/193868.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-05-25T12:57:00.000Z",
   "description": "peaceful ass bitches",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "214"
-    },
-    {
-      "player": "phil",
-      "score": "198"
-    },
-    {
-      "player": "ken",
-      "score": "153"
-    }
+    { "player": "aaron", "score": "214" },
+    { "player": "phil", "score": "198" },
+    { "player": "ken", "score": "153" }
   ]
 }

--- a/matches/tta/197157.json
+++ b/matches/tta/197157.json
@@ -4,36 +4,11 @@
   "updatedAt": "2013-06-11T00:12:00.000Z",
   "description": "Act I: The Sightless Matt",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "matt"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "matt", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "149"
-    },
-    {
-      "player": "phil",
-      "score": "139"
-    },
-    {
-      "player": "matt",
-      "score": "134"
-    },
-    {
-      "player": "aaron",
-      "score": "90"
-    }
+    { "player": "ken", "score": "149" },
+    { "player": "phil", "score": "139" },
+    { "player": "matt", "score": "134" },
+    { "player": "aaron", "score": "90" }
   ]
 }

--- a/matches/tta/197621.json
+++ b/matches/tta/197621.json
@@ -4,36 +4,11 @@
   "updatedAt": "2013-06-08T00:09:00.000Z",
   "description": "we require more vesphene gas (4)",
   "game": "tta",
-  "players": [
-    {
-      "id": "sean"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["sean", "ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "sean",
-      "score": "155"
-    },
-    {
-      "player": "ken",
-      "score": "151"
-    },
-    {
-      "player": "aaron",
-      "score": "134"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "sean", "score": "155" },
+    { "player": "ken", "score": "151" },
+    { "player": "aaron", "score": "134" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta/201624.json
+++ b/matches/tta/201624.json
@@ -4,36 +4,11 @@
   "updatedAt": "2013-06-21T00:34:00.000Z",
   "description": "Act II: The Secret of the Matt",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "matt"
-    }
-  ],
+  "players": ["aaron", "phil", "ken", "matt"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "169"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    },
-    {
-      "player": "matt",
-      "score": "-"
-    }
+    { "player": "aaron", "score": "169" },
+    { "player": "phil", "score": "-" },
+    { "player": "ken", "score": "-" },
+    { "player": "matt", "score": "-" }
   ]
 }

--- a/matches/tta/202950.json
+++ b/matches/tta/202950.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-07-04T11:10:00.000Z",
   "description": "Act III: The Infernal Matt",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "141"
-    },
-    {
-      "player": "phil",
-      "score": "130"
-    },
-    {
-      "player": "aaron",
-      "score": "106"
-    }
+    { "player": "ken", "score": "141" },
+    { "player": "phil", "score": "130" },
+    { "player": "aaron", "score": "106" }
   ]
 }

--- a/matches/tta/207179.json
+++ b/matches/tta/207179.json
@@ -4,22 +4,9 @@
   "updatedAt": "2013-07-06T19:18:00.000Z",
   "description": "this game name is too short",
   "game": "tta",
-  "players": [
-    {
-      "id": "matt"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["matt", "phil"],
   "results": [
-    {
-      "player": "matt",
-      "score": "92"
-    },
-    {
-      "player": "phil",
-      "score": "76"
-    }
+    { "player": "matt", "score": "92" },
+    { "player": "phil", "score": "76" }
   ]
 }

--- a/matches/tta/207409.json
+++ b/matches/tta/207409.json
@@ -4,36 +4,11 @@
   "updatedAt": "2013-07-10T18:09:00.000Z",
   "description": "Act IV: The Mattening",
   "game": "tta",
-  "players": [
-    {
-      "id": "matt"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["matt", "aaron", "ken", "phil"],
   "results": [
-    {
-      "player": "matt",
-      "score": "212"
-    },
-    {
-      "player": "aaron",
-      "score": "179"
-    },
-    {
-      "player": "ken",
-      "score": "146"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "matt", "score": "212" },
+    { "player": "aaron", "score": "179" },
+    { "player": "ken", "score": "146" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta/208620.json
+++ b/matches/tta/208620.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-07-22T15:22:00.000Z",
   "description": "Act III-2: This is how Square-Enix would do it",
   "game": "tta",
-  "players": [
-    {
-      "id": "matt"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["matt", "phil", "aaron"],
   "results": [
-    {
-      "player": "matt",
-      "score": "180"
-    },
-    {
-      "player": "phil",
-      "score": "162"
-    },
-    {
-      "player": "aaron",
-      "score": "118"
-    }
+    { "player": "matt", "score": "180" },
+    { "player": "phil", "score": "162" },
+    { "player": "aaron", "score": "118" }
   ]
 }

--- a/matches/tta/209435.json
+++ b/matches/tta/209435.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-07-17T15:53:00.000Z",
   "description": "TTA 9 to 5",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "133"
-    },
-    {
-      "player": "phil",
-      "score": "132"
-    },
-    {
-      "player": "aaron",
-      "score": "64"
-    }
+    { "player": "ken", "score": "133" },
+    { "player": "phil", "score": "132" },
+    { "player": "aaron", "score": "64" }
   ]
 }

--- a/matches/tta/211271.json
+++ b/matches/tta/211271.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-07-23T14:07:00.000Z",
   "description": "TTA 9 to 5: Round Two, Fight!",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "176"
-    },
-    {
-      "player": "phil",
-      "score": "172"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "176" },
+    { "player": "phil", "score": "172" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/211274.json
+++ b/matches/tta/211274.json
@@ -4,36 +4,11 @@
   "updatedAt": "2013-08-06T17:37:00.000Z",
   "description": "Act V: Matt of Destruction",
   "game": "tta",
-  "players": [
-    {
-      "id": "matt"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["matt", "aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "matt",
-      "score": "190"
-    },
-    {
-      "player": "aaron",
-      "score": "137"
-    },
-    {
-      "player": "phil",
-      "score": "130"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "matt", "score": "190" },
+    { "player": "aaron", "score": "137" },
+    { "player": "phil", "score": "130" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/211908.json
+++ b/matches/tta/211908.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-07-28T16:25:00.000Z",
   "description": "TTA 9 to 5: Ken goes for the hat trick",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "137"
-    },
-    {
-      "player": "phil",
-      "score": "111"
-    },
-    {
-      "player": "aaron",
-      "score": "88"
-    }
+    { "player": "ken", "score": "137" },
+    { "player": "phil", "score": "111" },
+    { "player": "aaron", "score": "88" }
   ]
 }

--- a/matches/tta/211910.json
+++ b/matches/tta/211910.json
@@ -4,22 +4,9 @@
   "updatedAt": "2013-07-26T15:33:00.000Z",
   "description": "Hurrrrrr",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "92"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "ken", "score": "92" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta/212825.json
+++ b/matches/tta/212825.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-07-31T09:22:00.000Z",
   "description": "TTA 9 to 5: Fourth time's a charm (for Ken to lose)",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "176"
-    },
-    {
-      "player": "ken",
-      "score": "129"
-    },
-    {
-      "player": "aaron",
-      "score": "106"
-    }
+    { "player": "phil", "score": "176" },
+    { "player": "ken", "score": "129" },
+    { "player": "aaron", "score": "106" }
   ]
 }

--- a/matches/tta/214637.json
+++ b/matches/tta/214637.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-07T11:35:00.000Z",
   "description": "TTA 9 to 5: Go fuck yourself, San Diego",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "140"
-    },
-    {
-      "player": "aaron",
-      "score": "106"
-    },
-    {
-      "player": "phil",
-      "score": "91"
-    }
+    { "player": "ken", "score": "140" },
+    { "player": "aaron", "score": "106" },
+    { "player": "phil", "score": "91" }
   ]
 }

--- a/matches/tta/215819.json
+++ b/matches/tta/215819.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-12T11:45:00.000Z",
   "description": "TTA 9 to 5: People took off today, so deadline postponed 'til Monday!",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["aaron", "ken", "phil"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "140"
-    },
-    {
-      "player": "ken",
-      "score": "138"
-    },
-    {
-      "player": "phil",
-      "score": "106"
-    }
+    { "player": "aaron", "score": "140" },
+    { "player": "ken", "score": "138" },
+    { "player": "phil", "score": "106" }
   ]
 }

--- a/matches/tta/216627.json
+++ b/matches/tta/216627.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-14T16:12:00.000Z",
   "description": "TTA 9 to 5: I immediately regret this decision.",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "136"
-    },
-    {
-      "player": "aaron",
-      "score": "129"
-    },
-    {
-      "player": "ken",
-      "score": "103"
-    }
+    { "player": "phil", "score": "136" },
+    { "player": "aaron", "score": "129" },
+    { "player": "ken", "score": "103" }
   ]
 }

--- a/matches/tta/217397.json
+++ b/matches/tta/217397.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-19T14:39:00.000Z",
   "description": "TTA 9 to 5: It's like Groundhog Day. We keep reliving it until Phil loses.",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "205"
-    },
-    {
-      "player": "aaron",
-      "score": "126"
-    },
-    {
-      "player": "ken",
-      "score": "126"
-    }
+    { "player": "phil", "score": "205" },
+    { "player": "aaron", "score": "126" },
+    { "player": "ken", "score": "126" }
   ]
 }

--- a/matches/tta/7106633.json
+++ b/matches/tta/7106633.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-20T17:56:00.000Z",
   "description": "TTA 9 to 5: Fuck Science",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "90"
-    },
-    {
-      "player": "phil",
-      "score": "84"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "90" },
+    { "player": "phil", "score": "84" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7107008.json
+++ b/matches/tta/7107008.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-22T00:35:00.000Z",
   "description": "TTA 9 to 5: Fuck Robespierre",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "178"
-    },
-    {
-      "player": "phil",
-      "score": "136"
-    },
-    {
-      "player": "aaron",
-      "score": "102"
-    }
+    { "player": "ken", "score": "178" },
+    { "player": "phil", "score": "136" },
+    { "player": "aaron", "score": "102" }
   ]
 }

--- a/matches/tta/7107517.json
+++ b/matches/tta/7107517.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-24T11:54:00.000Z",
   "description": "TTA 9 to 5: ??? Robespierre ???",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "178"
-    },
-    {
-      "player": "aaron",
-      "score": "165"
-    },
-    {
-      "player": "ken",
-      "score": "137"
-    }
+    { "player": "phil", "score": "178" },
+    { "player": "aaron", "score": "165" },
+    { "player": "ken", "score": "137" }
   ]
 }

--- a/matches/tta/7108085.json
+++ b/matches/tta/7108085.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-27T11:22:00.000Z",
   "description": "TTA 9 to 5: How I learned to stop worrying and love the revealed leaders/wonders",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "166"
-    },
-    {
-      "player": "aaron",
-      "score": "140"
-    },
-    {
-      "player": "ken",
-      "score": "130"
-    }
+    { "player": "phil", "score": "166" },
+    { "player": "aaron", "score": "140" },
+    { "player": "ken", "score": "130" }
   ]
 }

--- a/matches/tta/7108843.json
+++ b/matches/tta/7108843.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-28T12:01:00.000Z",
   "description": "TTA 9 to 5: Phillio must die",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "198"
-    },
-    {
-      "player": "aaron",
-      "score": "152"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "phil", "score": "198" },
+    { "player": "aaron", "score": "152" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7109354.json
+++ b/matches/tta/7109354.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-08-29T17:23:00.000Z",
   "description": "TTA 9 to 5: Phillio must really die this time",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "212"
-    },
-    {
-      "player": "aaron",
-      "score": "146"
-    },
-    {
-      "player": "phil",
-      "score": "103"
-    }
+    { "player": "ken", "score": "212" },
+    { "player": "aaron", "score": "146" },
+    { "player": "phil", "score": "103" }
   ]
 }

--- a/matches/tta/7110711.json
+++ b/matches/tta/7110711.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-09-04T11:04:00.000Z",
   "description": "TTA 9 to 5: 4 day workweek ohfuckyes",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "122"
-    },
-    {
-      "player": "ken",
-      "score": "122"
-    },
-    {
-      "player": "aaron",
-      "score": "82"
-    }
+    { "player": "phil", "score": "122" },
+    { "player": "ken", "score": "122" },
+    { "player": "aaron", "score": "82" }
   ]
 }

--- a/matches/tta/7111304.json
+++ b/matches/tta/7111304.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-09-06T13:43:00.000Z",
   "description": "TTA 9 to 5: A-Wing vs. TIE Fighters",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "95"
-    },
-    {
-      "player": "phil",
-      "score": "91"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "95" },
+    { "player": "phil", "score": "91" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7115582.json
+++ b/matches/tta/7115582.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-09-21T14:45:00.000Z",
   "description": "TTA 10 to 6",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "97"
-    },
-    {
-      "player": "phil",
-      "score": "87"
-    },
-    {
-      "player": "aaron",
-      "score": "45"
-    }
+    { "player": "ken", "score": "97" },
+    { "player": "phil", "score": "87" },
+    { "player": "aaron", "score": "45" }
   ]
 }

--- a/matches/tta/7118753.json
+++ b/matches/tta/7118753.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-10-09T17:51:00.000Z",
   "description": "TTA 10-6: Aaron's Revenge",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "193"
-    },
-    {
-      "player": "ken",
-      "score": "166"
-    },
-    {
-      "player": "aaron",
-      "score": "152"
-    }
+    { "player": "phil", "score": "193" },
+    { "player": "ken", "score": "166" },
+    { "player": "aaron", "score": "152" }
   ]
 }

--- a/matches/tta/7121342.json
+++ b/matches/tta/7121342.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-10-11T15:34:00.000Z",
   "description": "TTA 10-6: Event deck humps Phil",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "164"
-    },
-    {
-      "player": "aaron",
-      "score": "138"
-    },
-    {
-      "player": "phil",
-      "score": "135"
-    }
+    { "player": "ken", "score": "164" },
+    { "player": "aaron", "score": "138" },
+    { "player": "phil", "score": "135" }
   ]
 }

--- a/matches/tta/7121687.json
+++ b/matches/tta/7121687.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-10-14T21:11:00.000Z",
   "description": "Twilight: Teenage girl risks everything when she falls in love with Ken Mather",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["aaron", "ken", "phil"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "153"
-    },
-    {
-      "player": "ken",
-      "score": "138"
-    },
-    {
-      "player": "phil",
-      "score": "130"
-    }
+    { "player": "aaron", "score": "153" },
+    { "player": "ken", "score": "138" },
+    { "player": "phil", "score": "130" }
   ]
 }

--- a/matches/tta/7122762.json
+++ b/matches/tta/7122762.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-10-18T14:52:00.000Z",
   "description": "TTA 10-6: The Masonry-Dixon Line",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "150"
-    },
-    {
-      "player": "ken",
-      "score": "126"
-    },
-    {
-      "player": "aaron",
-      "score": "104"
-    }
+    { "player": "phil", "score": "150" },
+    { "player": "ken", "score": "126" },
+    { "player": "aaron", "score": "104" }
   ]
 }

--- a/matches/tta/7124458.json
+++ b/matches/tta/7124458.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-10-22T16:45:00.000Z",
   "description": "TTA 10-6: It's all the Buzzby",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "213"
-    },
-    {
-      "player": "ken",
-      "score": "157"
-    },
-    {
-      "player": "aaron",
-      "score": "140"
-    }
+    { "player": "phil", "score": "213" },
+    { "player": "ken", "score": "157" },
+    { "player": "aaron", "score": "140" }
   ]
 }

--- a/matches/tta/7125090.json
+++ b/matches/tta/7125090.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-10-28T22:12:00.000Z",
   "description": "TTA 10-6: Wrath of the Philistines",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "202"
-    },
-    {
-      "player": "phil",
-      "score": "177"
-    },
-    {
-      "player": "aaron",
-      "score": "169"
-    }
+    { "player": "ken", "score": "202" },
+    { "player": "phil", "score": "177" },
+    { "player": "aaron", "score": "169" }
   ]
 }

--- a/matches/tta/7127694.json
+++ b/matches/tta/7127694.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-11-04T00:22:00.000Z",
   "description": "TTA 10-6: Ken is literally Sadam Hussein",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "231"
-    },
-    {
-      "player": "aaron",
-      "score": "227"
-    },
-    {
-      "player": "ken",
-      "score": "149"
-    }
+    { "player": "phil", "score": "231" },
+    { "player": "aaron", "score": "227" },
+    { "player": "ken", "score": "149" }
   ]
 }

--- a/matches/tta/7129025.json
+++ b/matches/tta/7129025.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-11-07T23:08:00.000Z",
   "description": "TTA 10-6: Bite the pillow",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "171"
-    },
-    {
-      "player": "phil",
-      "score": "111"
-    },
-    {
-      "player": "aaron",
-      "score": "109"
-    }
+    { "player": "ken", "score": "171" },
+    { "player": "phil", "score": "111" },
+    { "player": "aaron", "score": "109" }
   ]
 }

--- a/matches/tta/7129986.json
+++ b/matches/tta/7129986.json
@@ -4,36 +4,11 @@
   "updatedAt": "2013-11-12T17:40:00.000Z",
   "description": "Don't trust Ken's lies.",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "Adam Badura"
-    }
-  ],
+  "players": ["phil", "aaron", "ken", "Adam Badura"],
   "results": [
-    {
-      "player": "phil",
-      "score": "202"
-    },
-    {
-      "player": "aaron",
-      "score": "157"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    },
-    {
-      "player": "Adam Badura",
-      "score": "-"
-    }
+    { "player": "phil", "score": "202" },
+    { "player": "aaron", "score": "157" },
+    { "player": "ken", "score": "-" },
+    { "player": "Adam Badura", "score": "-" }
   ]
 }

--- a/matches/tta/7131442.json
+++ b/matches/tta/7131442.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-11-21T15:05:00.000Z",
   "description": "The Best Offense is a Good Defensive Army",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "126"
-    },
-    {
-      "player": "ken",
-      "score": "123"
-    },
-    {
-      "player": "aaron",
-      "score": "80"
-    }
+    { "player": "phil", "score": "126" },
+    { "player": "ken", "score": "123" },
+    { "player": "aaron", "score": "80" }
   ]
 }

--- a/matches/tta/7133779.json
+++ b/matches/tta/7133779.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-11-23T16:57:00.000Z",
   "description": "\"The victor will never be asked if he told the truth.\" - Hitler",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "179"
-    },
-    {
-      "player": "ken",
-      "score": "157"
-    },
-    {
-      "player": "aaron",
-      "score": "111"
-    }
+    { "player": "phil", "score": "179" },
+    { "player": "ken", "score": "157" },
+    { "player": "aaron", "score": "111" }
   ]
 }

--- a/matches/tta/7134424.json
+++ b/matches/tta/7134424.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-11-26T23:23:00.000Z",
   "description": "\"Your victory is right around the corner. Never give up.\" Nicki Minaj",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "142"
-    },
-    {
-      "player": "ken",
-      "score": "137"
-    },
-    {
-      "player": "aaron",
-      "score": "97"
-    }
+    { "player": "phil", "score": "142" },
+    { "player": "ken", "score": "137" },
+    { "player": "aaron", "score": "97" }
   ]
 }

--- a/matches/tta/7135375.json
+++ b/matches/tta/7135375.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-01T16:53:00.000Z",
   "description": "The team that wins game five will win the series. Unless we lose game 5 -Barkley",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "121"
-    },
-    {
-      "player": "phil",
-      "score": "109"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "aaron", "score": "121" },
+    { "player": "phil", "score": "109" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7136515.json
+++ b/matches/tta/7136515.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-03T15:44:00.000Z",
   "description": "\"You know what makes a good loser? Practice.\"",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "155"
-    },
-    {
-      "player": "phil",
-      "score": "113"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "155" },
+    { "player": "phil", "score": "113" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7137246.json
+++ b/matches/tta/7137246.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-05T13:05:00.000Z",
   "description": "Desert Power",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "191"
-    },
-    {
-      "player": "aaron",
-      "score": "161"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "ken", "score": "191" },
+    { "player": "aaron", "score": "161" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta/7137818.json
+++ b/matches/tta/7137818.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-07T17:16:00.000Z",
   "description": "\"Victory has a thousand fathers.\" Basically, victory's mother is a whore.",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "214"
-    },
-    {
-      "player": "phil",
-      "score": "183"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "214" },
+    { "player": "phil", "score": "183" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7138445.json
+++ b/matches/tta/7138445.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-10T15:15:00.000Z",
   "description": "Episode 6: Aaron Strikes Back",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "107"
-    },
-    {
-      "player": "aaron",
-      "score": "92"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "ken", "score": "107" },
+    { "player": "aaron", "score": "92" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta/7139241.json
+++ b/matches/tta/7139241.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-11T15:31:00.000Z",
   "description": "Episode 7: Holiday Special",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "113"
-    },
-    {
-      "player": "aaron",
-      "score": "87"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "phil", "score": "113" },
+    { "player": "aaron", "score": "87" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7140148.json
+++ b/matches/tta/7140148.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-15T22:13:00.000Z",
   "description": "Episode 8: The Ocho",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "48"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "ken", "score": "48" },
+    { "player": "aaron", "score": "-" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta/7140692.json
+++ b/matches/tta/7140692.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-17T11:43:00.000Z",
   "description": "Episode 8b: This time's for real",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "136"
-    },
-    {
-      "player": "aaron",
-      "score": "114"
-    },
-    {
-      "player": "phil",
-      "score": "104"
-    }
+    { "player": "ken", "score": "136" },
+    { "player": "aaron", "score": "114" },
+    { "player": "phil", "score": "104" }
   ]
 }

--- a/matches/tta/7141189.json
+++ b/matches/tta/7141189.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-18T00:32:00.000Z",
   "description": "Episode 9: Nerf Ken",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "91"
-    },
-    {
-      "player": "phil",
-      "score": "83"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "aaron", "score": "91" },
+    { "player": "phil", "score": "83" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7141742.json
+++ b/matches/tta/7141742.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-24T13:07:00.000Z",
   "description": "Episode X: You Ruined Christmas",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "107"
-    },
-    {
-      "player": "phil",
-      "score": "81"
-    },
-    {
-      "player": "ken",
-      "score": "66"
-    }
+    { "player": "aaron", "score": "107" },
+    { "player": "phil", "score": "81" },
+    { "player": "ken", "score": "66" }
   ]
 }

--- a/matches/tta/7143021.json
+++ b/matches/tta/7143021.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-27T12:21:00.000Z",
   "description": "Episode XI: Daddy Drinks To Forget (You)",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["aaron", "ken", "phil"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "208"
-    },
-    {
-      "player": "ken",
-      "score": "202"
-    },
-    {
-      "player": "phil",
-      "score": "172"
-    }
+    { "player": "aaron", "score": "208" },
+    { "player": "ken", "score": "202" },
+    { "player": "phil", "score": "172" }
   ]
 }

--- a/matches/tta/7143637.json
+++ b/matches/tta/7143637.json
@@ -4,29 +4,10 @@
   "updatedAt": "2013-12-30T14:21:00.000Z",
   "description": "Episode XII: If there's grass on the field",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "183"
-    },
-    {
-      "player": "phil",
-      "score": "148"
-    },
-    {
-      "player": "aaron",
-      "score": "127"
-    }
+    { "player": "ken", "score": "183" },
+    { "player": "phil", "score": "148" },
+    { "player": "aaron", "score": "127" }
   ]
 }

--- a/matches/tta/7144762.json
+++ b/matches/tta/7144762.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-01-02T11:37:00.000Z",
   "description": "Episode XIII: ..Play ball. If there's not play in the mud",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "115"
-    },
-    {
-      "player": "ken",
-      "score": "69"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "phil", "score": "115" },
+    { "player": "ken", "score": "69" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7145435.json
+++ b/matches/tta/7145435.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-01-03T14:39:00.000Z",
   "description": "Episode XIV: Remember that time Phil got 11 CAs?",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "145"
-    },
-    {
-      "player": "phil",
-      "score": "143"
-    },
-    {
-      "player": "ken",
-      "score": "109"
-    }
+    { "player": "aaron", "score": "145" },
+    { "player": "phil", "score": "143" },
+    { "player": "ken", "score": "109" }
   ]
 }

--- a/matches/tta/7146673.json
+++ b/matches/tta/7146673.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-01-08T13:51:00.000Z",
   "description": "Episode XV: ( . Y . )",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "123"
-    },
-    {
-      "player": "aaron",
-      "score": "115"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "phil", "score": "123" },
+    { "player": "aaron", "score": "115" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7147297.json
+++ b/matches/tta/7147297.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-01-14T14:49:00.000Z",
   "description": "Episode XVI: Fuck Phil (2)",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "202"
-    },
-    {
-      "player": "aaron",
-      "score": "200"
-    },
-    {
-      "player": "ken",
-      "score": "183"
-    }
+    { "player": "phil", "score": "202" },
+    { "player": "aaron", "score": "200" },
+    { "player": "ken", "score": "183" }
   ]
 }

--- a/matches/tta/7149323.json
+++ b/matches/tta/7149323.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-01-16T13:31:00.000Z",
   "description": "Episode XVII: Dark Heart of Phil (3)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "177"
-    },
-    {
-      "player": "phil",
-      "score": "153"
-    },
-    {
-      "player": "aaron",
-      "score": "129"
-    }
+    { "player": "ken", "score": "177" },
+    { "player": "phil", "score": "153" },
+    { "player": "aaron", "score": "129" }
   ]
 }

--- a/matches/tta/7149710.json
+++ b/matches/tta/7149710.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-01-18T18:31:00.000Z",
   "description": "Episode XVIII: Cooke: A recipe for disaster",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "122"
-    },
-    {
-      "player": "phil",
-      "score": "121"
-    },
-    {
-      "player": "ken",
-      "score": "113"
-    }
+    { "player": "aaron", "score": "122" },
+    { "player": "phil", "score": "121" },
+    { "player": "ken", "score": "113" }
   ]
 }

--- a/matches/tta/7150311.json
+++ b/matches/tta/7150311.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-01-21T12:45:00.000Z",
   "description": "Episode XIX: Absolutely NEVER give pacts to Ken",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "106"
-    },
-    {
-      "player": "phil",
-      "score": "105"
-    },
-    {
-      "player": "ken",
-      "score": "97"
-    }
+    { "player": "aaron", "score": "106" },
+    { "player": "phil", "score": "105" },
+    { "player": "ken", "score": "97" }
   ]
 }

--- a/matches/tta/7151145.json
+++ b/matches/tta/7151145.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-01-21T21:07:00.000Z",
   "description": "Episode XX: Phil is DisaPoint",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["aaron", "ken", "phil"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "264"
-    },
-    {
-      "player": "ken",
-      "score": "252"
-    },
-    {
-      "player": "phil",
-      "score": "251"
-    }
+    { "player": "aaron", "score": "264" },
+    { "player": "ken", "score": "252" },
+    { "player": "phil", "score": "251" }
   ]
 }

--- a/matches/tta/7158063.json
+++ b/matches/tta/7158063.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-02-14T17:58:00.000Z",
   "description": "You know nothing, Snow",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "122"
-    },
-    {
-      "player": "aaron",
-      "score": "103"
-    },
-    {
-      "player": "phil",
-      "score": "94"
-    }
+    { "player": "ken", "score": "122" },
+    { "player": "aaron", "score": "103" },
+    { "player": "phil", "score": "94" }
   ]
 }

--- a/matches/tta/7161711.json
+++ b/matches/tta/7161711.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-03-05T17:23:00.000Z",
   "description": "Khannnnnnnnnnnn",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "153"
-    },
-    {
-      "player": "aaron",
-      "score": "111"
-    },
-    {
-      "player": "phil",
-      "score": "49"
-    }
+    { "player": "ken", "score": "153" },
+    { "player": "aaron", "score": "111" },
+    { "player": "phil", "score": "49" }
   ]
 }

--- a/matches/tta/7167972.json
+++ b/matches/tta/7167972.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-04-24T14:02:00.000Z",
   "description": "pizzatime",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "Nathan Sickler"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "Nathan Sickler", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "179"
-    },
-    {
-      "player": "phil",
-      "score": "147"
-    },
-    {
-      "player": "Nathan Sickler",
-      "score": "95"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "179" },
+    { "player": "phil", "score": "147" },
+    { "player": "Nathan Sickler", "score": "95" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7173395.json
+++ b/matches/tta/7173395.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-04-22T11:43:00.000Z",
   "description": "dickpix inside",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "tm b"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "tm b", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "173"
-    },
-    {
-      "player": "aaron",
-      "score": "170"
-    },
-    {
-      "player": "tm b",
-      "score": "78"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "phil", "score": "173" },
+    { "player": "aaron", "score": "170" },
+    { "player": "tm b", "score": "78" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7174179.json
+++ b/matches/tta/7174179.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-04-18T20:29:00.000Z",
   "description": "fuck slow players, i have tacos",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "160"
-    },
-    {
-      "player": "ken",
-      "score": "149"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "phil", "score": "160" },
+    { "player": "ken", "score": "149" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7177946.json
+++ b/matches/tta/7177946.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-06-18T00:35:00.000Z",
   "description": "ACT VI: Return of the Heath",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "Heath Gardner"
-    }
-  ],
+  "players": ["aaron", "ken", "phil", "Heath Gardner"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "169"
-    },
-    {
-      "player": "ken",
-      "score": "146"
-    },
-    {
-      "player": "phil",
-      "score": "143"
-    },
-    {
-      "player": "Heath Gardner",
-      "score": "-"
-    }
+    { "player": "aaron", "score": "169" },
+    { "player": "ken", "score": "146" },
+    { "player": "phil", "score": "143" },
+    { "player": "Heath Gardner", "score": "-" }
   ]
 }

--- a/matches/tta/7180510.json
+++ b/matches/tta/7180510.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-05-16T13:26:00.000Z",
   "description": "Too soon, Executus!",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "195"
-    },
-    {
-      "player": "phil",
-      "score": "128"
-    },
-    {
-      "player": "aaron",
-      "score": "127"
-    }
+    { "player": "ken", "score": "195" },
+    { "player": "phil", "score": "128" },
+    { "player": "aaron", "score": "127" }
   ]
 }

--- a/matches/tta/7181645.json
+++ b/matches/tta/7181645.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-05-21T12:29:00.000Z",
   "description": "That last game was merely a setback!",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "177"
-    },
-    {
-      "player": "phil",
-      "score": "169"
-    },
-    {
-      "player": "aaron",
-      "score": "169"
-    }
+    { "player": "ken", "score": "177" },
+    { "player": "phil", "score": "169" },
+    { "player": "aaron", "score": "169" }
   ]
 }

--- a/matches/tta/7182954.json
+++ b/matches/tta/7182954.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-05-24T01:59:00.000Z",
   "description": "Subgame 3 of the Heath Series",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "236"
-    },
-    {
-      "player": "aaron",
-      "score": "190"
-    },
-    {
-      "player": "ken",
-      "score": "188"
-    }
+    { "player": "phil", "score": "236" },
+    { "player": "aaron", "score": "190" },
+    { "player": "ken", "score": "188" }
   ]
 }

--- a/matches/tta/7183967.json
+++ b/matches/tta/7183967.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-06-04T14:37:00.000Z",
   "description": "Philihp ?'s Game",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    }
-  ],
+  "players": ["ken", "phil", "aaron", "ville"],
   "results": [
-    {
-      "player": "ken",
-      "score": "263"
-    },
-    {
-      "player": "phil",
-      "score": "249"
-    },
-    {
-      "player": "aaron",
-      "score": "218"
-    },
-    {
-      "player": "ville",
-      "score": "204"
-    }
+    { "player": "ken", "score": "263" },
+    { "player": "phil", "score": "249" },
+    { "player": "aaron", "score": "218" },
+    { "player": "ville", "score": "204" }
   ]
 }

--- a/matches/tta/7183969.json
+++ b/matches/tta/7183969.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-05-29T16:05:00.000Z",
   "description": "Philihp ?'s Game",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "146"
-    },
-    {
-      "player": "aaron",
-      "score": "97"
-    },
-    {
-      "player": "phil",
-      "score": "83"
-    }
+    { "player": "ken", "score": "146" },
+    { "player": "aaron", "score": "97" },
+    { "player": "phil", "score": "83" }
   ]
 }

--- a/matches/tta/7184816.json
+++ b/matches/tta/7184816.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-06-02T18:45:00.000Z",
   "description": "Cunts",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "133"
-    },
-    {
-      "player": "ken",
-      "score": "127"
-    },
-    {
-      "player": "aaron",
-      "score": "99"
-    }
+    { "player": "phil", "score": "133" },
+    { "player": "ken", "score": "127" },
+    { "player": "aaron", "score": "99" }
   ]
 }

--- a/matches/tta/7185719.json
+++ b/matches/tta/7185719.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-06-03T19:44:00.000Z",
   "description": "Fffffffuuuuuuuuuuuuu",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "27"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "ken", "score": "27" },
+    { "player": "aaron", "score": "-" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta/7186367.json
+++ b/matches/tta/7186367.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-06-14T23:58:00.000Z",
   "description": "\"Sometimes even if you lose, you win\"",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "ville", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "182"
-    },
-    {
-      "player": "ville",
-      "score": "172"
-    },
-    {
-      "player": "phil",
-      "score": "169"
-    },
-    {
-      "player": "ken",
-      "score": "149"
-    }
+    { "player": "aaron", "score": "182" },
+    { "player": "ville", "score": "172" },
+    { "player": "phil", "score": "169" },
+    { "player": "ken", "score": "149" }
   ]
 }

--- a/matches/tta/7188603.json
+++ b/matches/tta/7188603.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-06-25T11:13:00.000Z",
   "description": "The enemy of my enemy is... Phil",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ville", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "207"
-    },
-    {
-      "player": "ville",
-      "score": "205"
-    },
-    {
-      "player": "ken",
-      "score": "158"
-    },
-    {
-      "player": "aaron",
-      "score": "152"
-    }
+    { "player": "phil", "score": "207" },
+    { "player": "ville", "score": "205" },
+    { "player": "ken", "score": "158" },
+    { "player": "aaron", "score": "152" }
   ]
 }

--- a/matches/tta/7189396.json
+++ b/matches/tta/7189396.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-07-12T03:36:00.000Z",
   "description": "Adam's ADD knows no limits",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "adam"
-    }
-  ],
+  "players": ["aaron", "ken", "phil", "adam"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "241"
-    },
-    {
-      "player": "ken",
-      "score": "201"
-    },
-    {
-      "player": "phil",
-      "score": "113"
-    },
-    {
-      "player": "adam",
-      "score": "-"
-    }
+    { "player": "aaron", "score": "241" },
+    { "player": "ken", "score": "201" },
+    { "player": "phil", "score": "113" },
+    { "player": "adam", "score": "-" }
   ]
 }

--- a/matches/tta/7189777.json
+++ b/matches/tta/7189777.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-06-21T14:07:00.000Z",
   "description": "3p is the best p",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "109"
-    },
-    {
-      "player": "aaron",
-      "score": "92"
-    },
-    {
-      "player": "ken",
-      "score": "90"
-    }
+    { "player": "phil", "score": "109" },
+    { "player": "aaron", "score": "92" },
+    { "player": "ken", "score": "90" }
   ]
 }

--- a/matches/tta/7190875.json
+++ b/matches/tta/7190875.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-07-02T13:25:00.000Z",
   "description": "Ken learns War determines who is left, not who is right. And Phil's a whore",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "233"
-    },
-    {
-      "player": "phil",
-      "score": "221"
-    },
-    {
-      "player": "aaron",
-      "score": "191"
-    },
-    {
-      "player": "ken",
-      "score": "186"
-    }
+    { "player": "ville", "score": "233" },
+    { "player": "phil", "score": "221" },
+    { "player": "aaron", "score": "191" },
+    { "player": "ken", "score": "186" }
   ]
 }

--- a/matches/tta/7192328.json
+++ b/matches/tta/7192328.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-07-09T18:15:00.000Z",
   "description": "Cooking up trouble",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    }
-  ],
+  "players": ["ken", "phil", "aaron", "ville"],
   "results": [
-    {
-      "player": "ken",
-      "score": "309"
-    },
-    {
-      "player": "phil",
-      "score": "259"
-    },
-    {
-      "player": "aaron",
-      "score": "245"
-    },
-    {
-      "player": "ville",
-      "score": "219"
-    }
+    { "player": "ken", "score": "309" },
+    { "player": "phil", "score": "259" },
+    { "player": "aaron", "score": "245" },
+    { "player": "ville", "score": "219" }
   ]
 }

--- a/matches/tta/7193858.json
+++ b/matches/tta/7193858.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-08-03T14:24:00.000Z",
   "description": "The 300 club (Spoilers they died)",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "ville", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "289"
-    },
-    {
-      "player": "ville",
-      "score": "280"
-    },
-    {
-      "player": "phil",
-      "score": "200"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "aaron", "score": "289" },
+    { "player": "ville", "score": "280" },
+    { "player": "phil", "score": "200" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7197022.json
+++ b/matches/tta/7197022.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-08-07T12:13:00.000Z",
   "description": "sick of waiting for aaron to get back",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "ville", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "125"
-    },
-    {
-      "player": "ville",
-      "score": "109"
-    },
-    {
-      "player": "ken",
-      "score": "81"
-    }
+    { "player": "phil", "score": "125" },
+    { "player": "ville", "score": "109" },
+    { "player": "ken", "score": "81" }
   ]
 }

--- a/matches/tta/7199517.json
+++ b/matches/tta/7199517.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-08-18T03:13:00.000Z",
   "description": "democracy never works",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "ville", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "136"
-    },
-    {
-      "player": "phil",
-      "score": "129"
-    },
-    {
-      "player": "ville",
-      "score": "124"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "136" },
+    { "player": "phil", "score": "129" },
+    { "player": "ville", "score": "124" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7201503.json
+++ b/matches/tta/7201503.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-09-06T22:28:00.000Z",
   "description": "This is why we can't have nice things.",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "172"
-    },
-    {
-      "player": "phil",
-      "score": "157"
-    },
-    {
-      "player": "aaron",
-      "score": "103"
-    },
-    {
-      "player": "ken",
-      "score": "94"
-    }
+    { "player": "ville", "score": "172" },
+    { "player": "phil", "score": "157" },
+    { "player": "aaron", "score": "103" },
+    { "player": "ken", "score": "94" }
   ]
 }

--- a/matches/tta/7205695.json
+++ b/matches/tta/7205695.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-09-15T07:26:00.000Z",
   "description": "This is why we can't have nice things. (2)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "188"
-    },
-    {
-      "player": "ken",
-      "score": "153"
-    },
-    {
-      "player": "phil",
-      "score": "153"
-    },
-    {
-      "player": "aaron",
-      "score": "100"
-    }
+    { "player": "ville", "score": "188" },
+    { "player": "ken", "score": "153" },
+    { "player": "phil", "score": "153" },
+    { "player": "aaron", "score": "100" }
   ]
 }

--- a/matches/tta/7207514.json
+++ b/matches/tta/7207514.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-09-23T12:05:00.000Z",
   "description": "This is why we can't have nice things. (3)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    }
-  ],
+  "players": ["ken", "aaron", "phil", "ville"],
   "results": [
-    {
-      "player": "ken",
-      "score": "160"
-    },
-    {
-      "player": "aaron",
-      "score": "135"
-    },
-    {
-      "player": "phil",
-      "score": "118"
-    },
-    {
-      "player": "ville",
-      "score": "109"
-    }
+    { "player": "ken", "score": "160" },
+    { "player": "aaron", "score": "135" },
+    { "player": "phil", "score": "118" },
+    { "player": "ville", "score": "109" }
   ]
 }

--- a/matches/tta/7209310.json
+++ b/matches/tta/7209310.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-10-03T12:53:00.000Z",
   "description": "This is why we can't have nice things. (4)",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "ville", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "215"
-    },
-    {
-      "player": "ville",
-      "score": "202"
-    },
-    {
-      "player": "aaron",
-      "score": "152"
-    },
-    {
-      "player": "ken",
-      "score": "141"
-    }
+    { "player": "phil", "score": "215" },
+    { "player": "ville", "score": "202" },
+    { "player": "aaron", "score": "152" },
+    { "player": "ken", "score": "141" }
   ]
 }

--- a/matches/tta/7211581.json
+++ b/matches/tta/7211581.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-10-13T17:47:00.000Z",
   "description": "This is why we can't have nice things. (5)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "ville", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "188"
-    },
-    {
-      "player": "ville",
-      "score": "172"
-    },
-    {
-      "player": "phil",
-      "score": "118"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "188" },
+    { "player": "ville", "score": "172" },
+    { "player": "phil", "score": "118" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7214121.json
+++ b/matches/tta/7214121.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-10-22T17:57:00.000Z",
   "description": "This is why we can't have nice things. (6)",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "ville", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "199"
-    },
-    {
-      "player": "ken",
-      "score": "189"
-    },
-    {
-      "player": "ville",
-      "score": "151"
-    },
-    {
-      "player": "aaron",
-      "score": "138"
-    }
+    { "player": "phil", "score": "199" },
+    { "player": "ken", "score": "189" },
+    { "player": "ville", "score": "151" },
+    { "player": "aaron", "score": "138" }
   ]
 }

--- a/matches/tta/7216091.json
+++ b/matches/tta/7216091.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-10-29T15:29:00.000Z",
   "description": "This is why we can't have nice things. (7)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "217"
-    },
-    {
-      "player": "phil",
-      "score": "207"
-    },
-    {
-      "player": "aaron",
-      "score": "183"
-    },
-    {
-      "player": "ken",
-      "score": "175"
-    }
+    { "player": "ville", "score": "217" },
+    { "player": "phil", "score": "207" },
+    { "player": "aaron", "score": "183" },
+    { "player": "ken", "score": "175" }
   ]
 }

--- a/matches/tta/7217593.json
+++ b/matches/tta/7217593.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-11-10T07:02:00.000Z",
   "description": "This is why we can't have nice things. (8)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "255"
-    },
-    {
-      "player": "ken",
-      "score": "166"
-    },
-    {
-      "player": "phil",
-      "score": "163"
-    },
-    {
-      "player": "aaron",
-      "score": "148"
-    }
+    { "player": "ville", "score": "255" },
+    { "player": "ken", "score": "166" },
+    { "player": "phil", "score": "163" },
+    { "player": "aaron", "score": "148" }
   ]
 }

--- a/matches/tta/7218940.json
+++ b/matches/tta/7218940.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-11-10T13:29:00.000Z",
   "description": "For England, James?",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "113"
-    },
-    {
-      "player": "aaron",
-      "score": "95"
-    },
-    {
-      "player": "ken",
-      "score": "94"
-    }
+    { "player": "phil", "score": "113" },
+    { "player": "aaron", "score": "95" },
+    { "player": "ken", "score": "94" }
   ]
 }

--- a/matches/tta/7219871.json
+++ b/matches/tta/7219871.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-11-18T18:49:00.000Z",
   "description": "\"No. For me.\" -James Bond",
   "game": "tta",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "120"
-    },
-    {
-      "player": "phil",
-      "score": "73"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "aaron", "score": "120" },
+    { "player": "phil", "score": "73" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7219872.json
+++ b/matches/tta/7219872.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-11-24T17:39:00.000Z",
   "description": "This is why we can't have nice things. (9)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "189"
-    },
-    {
-      "player": "aaron",
-      "score": "175"
-    },
-    {
-      "player": "phil",
-      "score": "156"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "ville", "score": "189" },
+    { "player": "aaron", "score": "175" },
+    { "player": "phil", "score": "156" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7221635.json
+++ b/matches/tta/7221635.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-11-23T19:59:00.000Z",
   "description": "The Eiffel Tower of War",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "97"
-    },
-    {
-      "player": "ken",
-      "score": "96"
-    },
-    {
-      "player": "aaron",
-      "score": "61"
-    }
+    { "player": "phil", "score": "97" },
+    { "player": "ken", "score": "96" },
+    { "player": "aaron", "score": "61" }
   ]
 }

--- a/matches/tta/7222862.json
+++ b/matches/tta/7222862.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-12-05T09:11:00.000Z",
   "description": "This is why we can't have nice things. (10)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "ville", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "244"
-    },
-    {
-      "player": "ville",
-      "score": "229"
-    },
-    {
-      "player": "aaron",
-      "score": "205"
-    },
-    {
-      "player": "phil",
-      "score": "197"
-    }
+    { "player": "ken", "score": "244" },
+    { "player": "ville", "score": "229" },
+    { "player": "aaron", "score": "205" },
+    { "player": "phil", "score": "197" }
   ]
 }

--- a/matches/tta/7222999.json
+++ b/matches/tta/7222999.json
@@ -4,29 +4,10 @@
   "updatedAt": "2014-12-01T17:14:00.000Z",
   "description": "?I?ll do anything for a woman with a knife.? -James Bond",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "207"
-    },
-    {
-      "player": "aaron",
-      "score": "157"
-    },
-    {
-      "player": "ken",
-      "score": "113"
-    }
+    { "player": "phil", "score": "207" },
+    { "player": "aaron", "score": "157" },
+    { "player": "ken", "score": "113" }
   ]
 }

--- a/matches/tta/7225196.json
+++ b/matches/tta/7225196.json
@@ -4,36 +4,11 @@
   "updatedAt": "2014-12-19T11:36:00.000Z",
   "description": "This is why we can't have nice things. (11)",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    }
-  ],
+  "players": ["phil", "ken", "aaron", "ville"],
   "results": [
-    {
-      "player": "phil",
-      "score": "173"
-    },
-    {
-      "player": "ken",
-      "score": "153"
-    },
-    {
-      "player": "aaron",
-      "score": "123"
-    },
-    {
-      "player": "ville",
-      "score": "102"
-    }
+    { "player": "phil", "score": "173" },
+    { "player": "ken", "score": "153" },
+    { "player": "aaron", "score": "123" },
+    { "player": "ville", "score": "102" }
   ]
 }

--- a/matches/tta/7228056.json
+++ b/matches/tta/7228056.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-01-03T22:02:00.000Z",
   "description": "This is why we can't have nice things. (12)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "ville", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "258"
-    },
-    {
-      "player": "phil",
-      "score": "250"
-    },
-    {
-      "player": "ville",
-      "score": "212"
-    },
-    {
-      "player": "aaron",
-      "score": "211"
-    }
+    { "player": "ken", "score": "258" },
+    { "player": "phil", "score": "250" },
+    { "player": "ville", "score": "212" },
+    { "player": "aaron", "score": "211" }
   ]
 }

--- a/matches/tta/7233043.json
+++ b/matches/tta/7233043.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-02-02T18:56:00.000Z",
   "description": "Phil's back party's over",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "142"
-    },
-    {
-      "player": "phil",
-      "score": "107"
-    },
-    {
-      "player": "aaron",
-      "score": "99"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "ville", "score": "142" },
+    { "player": "phil", "score": "107" },
+    { "player": "aaron", "score": "99" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7237206.json
+++ b/matches/tta/7237206.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-02-17T01:59:00.000Z",
   "description": "This is why we can't have nice things. (13)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    }
-  ],
+  "players": ["ken", "aaron", "phil", "ville"],
   "results": [
-    {
-      "player": "ken",
-      "score": "205"
-    },
-    {
-      "player": "aaron",
-      "score": "174"
-    },
-    {
-      "player": "phil",
-      "score": "170"
-    },
-    {
-      "player": "ville",
-      "score": "153"
-    }
+    { "player": "ken", "score": "205" },
+    { "player": "aaron", "score": "174" },
+    { "player": "phil", "score": "170" },
+    { "player": "ville", "score": "153" }
   ]
 }

--- a/matches/tta/7240341.json
+++ b/matches/tta/7240341.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-03-04T15:52:00.000Z",
   "description": "This is why we can't have nice things. (14)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    }
-  ],
+  "players": ["ken", "aaron", "phil", "ville"],
   "results": [
-    {
-      "player": "ken",
-      "score": "203"
-    },
-    {
-      "player": "aaron",
-      "score": "162"
-    },
-    {
-      "player": "phil",
-      "score": "144"
-    },
-    {
-      "player": "ville",
-      "score": "134"
-    }
+    { "player": "ken", "score": "203" },
+    { "player": "aaron", "score": "162" },
+    { "player": "phil", "score": "144" },
+    { "player": "ville", "score": "134" }
   ]
 }

--- a/matches/tta/7243374.json
+++ b/matches/tta/7243374.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-03-18T02:05:00.000Z",
   "description": "This is why we can't have nice things. (15)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "ville", "aaron", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "183"
-    },
-    {
-      "player": "ville",
-      "score": "136"
-    },
-    {
-      "player": "aaron",
-      "score": "125"
-    },
-    {
-      "player": "phil",
-      "score": "110"
-    }
+    { "player": "ken", "score": "183" },
+    { "player": "ville", "score": "136" },
+    { "player": "aaron", "score": "125" },
+    { "player": "phil", "score": "110" }
   ]
 }

--- a/matches/tta/7245871.json
+++ b/matches/tta/7245871.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-04-16T00:46:00.000Z",
   "description": "This is why we can't have nice things. (16)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "144"
-    },
-    {
-      "player": "aaron",
-      "score": "138"
-    },
-    {
-      "player": "phil",
-      "score": "127"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "ville", "score": "144" },
+    { "player": "aaron", "score": "138" },
+    { "player": "phil", "score": "127" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7251205.json
+++ b/matches/tta/7251205.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-05-10T00:35:00.000Z",
   "description": "This is why we can't have nice things. (17)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "170"
-    },
-    {
-      "player": "ken",
-      "score": "157"
-    },
-    {
-      "player": "phil",
-      "score": "143"
-    },
-    {
-      "player": "aaron",
-      "score": "116"
-    }
+    { "player": "ville", "score": "170" },
+    { "player": "ken", "score": "157" },
+    { "player": "phil", "score": "143" },
+    { "player": "aaron", "score": "116" }
   ]
 }

--- a/matches/tta/7256098.json
+++ b/matches/tta/7256098.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-05-28T03:02:00.000Z",
   "description": "Phil is why we ken't have nice things. (18)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "154"
-    },
-    {
-      "player": "ken",
-      "score": "125"
-    },
-    {
-      "player": "phil",
-      "score": "125"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ville", "score": "154" },
+    { "player": "ken", "score": "125" },
+    { "player": "phil", "score": "125" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7259244.json
+++ b/matches/tta/7259244.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-06-30T10:38:00.000Z",
   "description": "Because there is good and there is evil, and Ville must be punished.",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "ville", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "224"
-    },
-    {
-      "player": "ken",
-      "score": "175"
-    },
-    {
-      "player": "ville",
-      "score": "169"
-    },
-    {
-      "player": "aaron",
-      "score": "155"
-    }
+    { "player": "phil", "score": "224" },
+    { "player": "ken", "score": "175" },
+    { "player": "ville", "score": "169" },
+    { "player": "aaron", "score": "155" }
   ]
 }

--- a/matches/tta/7265571.json
+++ b/matches/tta/7265571.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-07-26T16:19:00.000Z",
   "description": "this is why we can't have nice things (999)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "184"
-    },
-    {
-      "player": "phil",
-      "score": "172"
-    },
-    {
-      "player": "ken",
-      "score": "164"
-    },
-    {
-      "player": "aaron",
-      "score": "139"
-    }
+    { "player": "ville", "score": "184" },
+    { "player": "phil", "score": "172" },
+    { "player": "ken", "score": "164" },
+    { "player": "aaron", "score": "139" }
   ]
 }

--- a/matches/tta/7269306.json
+++ b/matches/tta/7269306.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-08-21T14:09:00.000Z",
   "description": "this is why we can't have nice things (1000)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "192"
-    },
-    {
-      "player": "phil",
-      "score": "175"
-    },
-    {
-      "player": "ken",
-      "score": "160"
-    },
-    {
-      "player": "aaron",
-      "score": "120"
-    }
+    { "player": "ville", "score": "192" },
+    { "player": "phil", "score": "175" },
+    { "player": "ken", "score": "160" },
+    { "player": "aaron", "score": "120" }
   ]
 }

--- a/matches/tta/7273825.json
+++ b/matches/tta/7273825.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-09-27T14:16:00.000Z",
   "description": "this is why we can't have nice things (1001)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "phil", "aaron", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "277"
-    },
-    {
-      "player": "phil",
-      "score": "251"
-    },
-    {
-      "player": "aaron",
-      "score": "172"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "ville", "score": "277" },
+    { "player": "phil", "score": "251" },
+    { "player": "aaron", "score": "172" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta/7279882.json
+++ b/matches/tta/7279882.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-10-11T19:29:00.000Z",
   "description": "this is why we can't have nice things (1002)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "208"
-    },
-    {
-      "player": "aaron",
-      "score": "195"
-    },
-    {
-      "player": "phil",
-      "score": "186"
-    },
-    {
-      "player": "ken",
-      "score": "176"
-    }
+    { "player": "ville", "score": "208" },
+    { "player": "aaron", "score": "195" },
+    { "player": "phil", "score": "186" },
+    { "player": "ken", "score": "176" }
   ]
 }

--- a/matches/tta/7282224.json
+++ b/matches/tta/7282224.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-10-22T17:00:00.000Z",
   "description": "this is why we can't have nice things (1003)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "ville", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "155"
-    },
-    {
-      "player": "ville",
-      "score": "132"
-    },
-    {
-      "player": "phil",
-      "score": "127"
-    },
-    {
-      "player": "aaron",
-      "score": "122"
-    }
+    { "player": "ken", "score": "155" },
+    { "player": "ville", "score": "132" },
+    { "player": "phil", "score": "127" },
+    { "player": "aaron", "score": "122" }
   ]
 }

--- a/matches/tta/7283981.json
+++ b/matches/tta/7283981.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-11-02T19:18:00.000Z",
   "description": "this is why we can't have nice things (1004)",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    }
-  ],
+  "players": ["phil", "ken", "aaron", "ville"],
   "results": [
-    {
-      "player": "phil",
-      "score": "226"
-    },
-    {
-      "player": "ken",
-      "score": "221"
-    },
-    {
-      "player": "aaron",
-      "score": "196"
-    },
-    {
-      "player": "ville",
-      "score": "185"
-    }
+    { "player": "phil", "score": "226" },
+    { "player": "ken", "score": "221" },
+    { "player": "aaron", "score": "196" },
+    { "player": "ville", "score": "185" }
   ]
 }

--- a/matches/tta/7285726.json
+++ b/matches/tta/7285726.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-11-19T14:25:00.000Z",
   "description": "this is why we can't have nice things (1005)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "ville", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "201"
-    },
-    {
-      "player": "phil",
-      "score": "169"
-    },
-    {
-      "player": "ville",
-      "score": "160"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "201" },
+    { "player": "phil", "score": "169" },
+    { "player": "ville", "score": "160" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta/7288485.json
+++ b/matches/tta/7288485.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-12-11T09:26:00.000Z",
   "description": "this is why we can't have nice things (1006)",
   "game": "tta",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ville", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "242"
-    },
-    {
-      "player": "ville",
-      "score": "207"
-    },
-    {
-      "player": "ken",
-      "score": "194"
-    },
-    {
-      "player": "aaron",
-      "score": "123"
-    }
+    { "player": "phil", "score": "242" },
+    { "player": "ville", "score": "207" },
+    { "player": "ken", "score": "194" },
+    { "player": "aaron", "score": "123" }
   ]
 }

--- a/matches/tta/7292129.json
+++ b/matches/tta/7292129.json
@@ -4,36 +4,11 @@
   "updatedAt": "2015-12-28T10:31:00.000Z",
   "description": "this is why we can't have nice things (1007)",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "198"
-    },
-    {
-      "player": "aaron",
-      "score": "186"
-    },
-    {
-      "player": "phil",
-      "score": "167"
-    },
-    {
-      "player": "ken",
-      "score": "150"
-    }
+    { "player": "ville", "score": "198" },
+    { "player": "aaron", "score": "186" },
+    { "player": "phil", "score": "167" },
+    { "player": "ken", "score": "150" }
   ]
 }

--- a/matches/tta/7294393.json
+++ b/matches/tta/7294393.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-01-08T14:27:00.000Z",
   "description": "Always help Phil! Or Philihp! .. or Fil.. or Phill",
   "game": "tta",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ville", "ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ville",
-      "score": "167"
-    },
-    {
-      "player": "ken",
-      "score": "162"
-    },
-    {
-      "player": "aaron",
-      "score": "155"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "ville", "score": "167" },
+    { "player": "ken", "score": "162" },
+    { "player": "aaron", "score": "155" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta2/2020B.json
+++ b/matches/tta2/2020B.json
@@ -5,36 +5,11 @@
   "location": "TTA App",
   "description": "2020B",
   "game": "tta2",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "adam"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["aaron", "ken", "adam", "phil"],
   "results": [
-    {
-      "player": "phil",
-      "score": 222
-    },
-    {
-      "player": "ken",
-      "score": 163
-    },
-    {
-      "player": "aaron",
-      "score": 135
-    },
-    {
-      "player": "adam",
-      "score": 106
-    }
+    { "player": "phil", "score": 222 },
+    { "player": "ken", "score": 163 },
+    { "player": "aaron", "score": 135 },
+    { "player": "adam", "score": 106 }
   ]
 }

--- a/matches/tta2/2020C.json
+++ b/matches/tta2/2020C.json
@@ -5,36 +5,11 @@
   "location": "TTA App",
   "description": "2020C",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "matt"
-    },
-    {
-      "id": "adam"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "matt", "adam", "phil"],
   "results": [
-    {
-      "player": "phil",
-      "score": 174
-    },
-    {
-      "player": "adam",
-      "score": 158
-    },
-    {
-      "player": "matt",
-      "score": 0
-    },
-    {
-      "player": "ken",
-      "score": 0
-    }
+    { "player": "phil", "score": 174 },
+    { "player": "adam", "score": 158 },
+    { "player": "matt", "score": 0 },
+    { "player": "ken", "score": 0 }
   ]
 }

--- a/matches/tta2/7295029.json
+++ b/matches/tta2/7295029.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-04-08T15:45:00.000Z",
   "description": "Lets give this a try",
   "game": "tta2",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "jonathan wilcox"
-    },
-    {
-      "id": "Iron James"
-    },
-    {
-      "id": "Lee Nicholas"
-    }
-  ],
+  "players": ["phil", "jonathan wilcox", "Iron James", "Lee Nicholas"],
   "results": [
-    {
-      "player": "phil",
-      "score": "244"
-    },
-    {
-      "player": "jonathan wilcox",
-      "score": "243"
-    },
-    {
-      "player": "Iron James",
-      "score": "-"
-    },
-    {
-      "player": "Lee Nicholas",
-      "score": "-"
-    }
+    { "player": "phil", "score": "244" },
+    { "player": "jonathan wilcox", "score": "243" },
+    { "player": "Iron James", "score": "-" },
+    { "player": "Lee Nicholas", "score": "-" }
   ]
 }

--- a/matches/tta2/7297875.json
+++ b/matches/tta2/7297875.json
@@ -4,29 +4,10 @@
   "updatedAt": "2016-05-16T21:59:00.000Z",
   "description": "See 3p ohh",
   "game": "tta2",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["aaron", "ken", "phil"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "136"
-    },
-    {
-      "player": "ken",
-      "score": "120"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "aaron", "score": "136" },
+    { "player": "ken", "score": "120" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta2/7299675.json
+++ b/matches/tta2/7299675.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-02-19T00:58:00.000Z",
   "description": "a56c54f2-4c30-44bc-a9c8-35ae9c307a30",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "249"
-    },
-    {
-      "player": "phil",
-      "score": "222"
-    },
-    {
-      "player": "ken",
-      "score": "215"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ville", "score": "249" },
+    { "player": "phil", "score": "222" },
+    { "player": "ken", "score": "215" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta2/7305566.json
+++ b/matches/tta2/7305566.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-03-14T15:55:00.000Z",
   "description": "I love the smell of napalm in the morning",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["ville", "aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "ville",
-      "score": "173"
-    },
-    {
-      "player": "aaron",
-      "score": "137"
-    },
-    {
-      "player": "phil",
-      "score": "136"
-    },
-    {
-      "player": "ken",
-      "score": "-"
-    }
+    { "player": "ville", "score": "173" },
+    { "player": "aaron", "score": "137" },
+    { "player": "phil", "score": "136" },
+    { "player": "ken", "score": "-" }
   ]
 }

--- a/matches/tta2/7310667.json
+++ b/matches/tta2/7310667.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-04-19T12:09:00.000Z",
   "description": "All that is necessary for the triumph of Ville is that bad men do nothing",
   "game": "tta2",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ville", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "250"
-    },
-    {
-      "player": "ville",
-      "score": "236"
-    },
-    {
-      "player": "ken",
-      "score": "197"
-    },
-    {
-      "player": "aaron",
-      "score": "163"
-    }
+    { "player": "phil", "score": "250" },
+    { "player": "ville", "score": "236" },
+    { "player": "ken", "score": "197" },
+    { "player": "aaron", "score": "163" }
   ]
 }

--- a/matches/tta2/7317104.json
+++ b/matches/tta2/7317104.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-05-19T00:21:00.000Z",
   "description": "2016D",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "phil", "ken", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "161"
-    },
-    {
-      "player": "phil",
-      "score": "150"
-    },
-    {
-      "player": "ken",
-      "score": "144"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ville", "score": "161" },
+    { "player": "phil", "score": "150" },
+    { "player": "ken", "score": "144" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta2/7322202.json
+++ b/matches/tta2/7322202.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-06-23T18:25:00.000Z",
   "description": "2016E",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "ville", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "180"
-    },
-    {
-      "player": "aaron",
-      "score": "165"
-    },
-    {
-      "player": "ville",
-      "score": "149"
-    },
-    {
-      "player": "phil",
-      "score": "126"
-    }
+    { "player": "ken", "score": "180" },
+    { "player": "aaron", "score": "165" },
+    { "player": "ville", "score": "149" },
+    { "player": "phil", "score": "126" }
   ]
 }

--- a/matches/tta2/7328080.json
+++ b/matches/tta2/7328080.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-08-22T23:02:00.000Z",
   "description": "2016F",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    }
-  ],
+  "players": ["ken", "phil", "aaron", "ville"],
   "results": [
-    {
-      "player": "ken",
-      "score": "194"
-    },
-    {
-      "player": "phil",
-      "score": "165"
-    },
-    {
-      "player": "aaron",
-      "score": "156"
-    },
-    {
-      "player": "ville",
-      "score": "155"
-    }
+    { "player": "ken", "score": "194" },
+    { "player": "phil", "score": "165" },
+    { "player": "aaron", "score": "156" },
+    { "player": "ville", "score": "155" }
   ]
 }

--- a/matches/tta2/7332543.json
+++ b/matches/tta2/7332543.json
@@ -4,29 +4,10 @@
   "updatedAt": "2016-08-10T12:39:00.000Z",
   "description": "Vacation for (from) Aaron",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    }
-  ],
+  "players": ["ken", "phil", "ville"],
   "results": [
-    {
-      "player": "ken",
-      "score": "126"
-    },
-    {
-      "player": "phil",
-      "score": "104"
-    },
-    {
-      "player": "ville",
-      "score": "92"
-    }
+    { "player": "ken", "score": "126" },
+    { "player": "phil", "score": "104" },
+    { "player": "ville", "score": "92" }
   ]
 }

--- a/matches/tta2/7338085.json
+++ b/matches/tta2/7338085.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-09-29T02:04:00.000Z",
   "description": "2016G",
   "game": "tta2",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["phil", "ville", "aaron", "ken"],
   "results": [
-    {
-      "player": "phil",
-      "score": "176"
-    },
-    {
-      "player": "ville",
-      "score": "164"
-    },
-    {
-      "player": "aaron",
-      "score": "148"
-    },
-    {
-      "player": "ken",
-      "score": "125"
-    }
+    { "player": "phil", "score": "176" },
+    { "player": "ville", "score": "164" },
+    { "player": "aaron", "score": "148" },
+    { "player": "ken", "score": "125" }
   ]
 }

--- a/matches/tta2/7344939.json
+++ b/matches/tta2/7344939.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-11-16T02:53:00.000Z",
   "description": "2016H",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "phil", "ville", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "180"
-    },
-    {
-      "player": "phil",
-      "score": "169"
-    },
-    {
-      "player": "ville",
-      "score": "158"
-    },
-    {
-      "player": "aaron",
-      "score": "149"
-    }
+    { "player": "ken", "score": "180" },
+    { "player": "phil", "score": "169" },
+    { "player": "ville", "score": "158" },
+    { "player": "aaron", "score": "149" }
   ]
 }

--- a/matches/tta2/7353615.json
+++ b/matches/tta2/7353615.json
@@ -4,36 +4,11 @@
   "updatedAt": "2016-12-28T14:27:00.000Z",
   "description": "2016I",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ville", "ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ville",
-      "score": "187"
-    },
-    {
-      "player": "ken",
-      "score": "159"
-    },
-    {
-      "player": "aaron",
-      "score": "131"
-    },
-    {
-      "player": "phil",
-      "score": "125"
-    }
+    { "player": "ville", "score": "187" },
+    { "player": "ken", "score": "159" },
+    { "player": "aaron", "score": "131" },
+    { "player": "phil", "score": "125" }
   ]
 }

--- a/matches/tta2/7360640.json
+++ b/matches/tta2/7360640.json
@@ -4,36 +4,11 @@
   "updatedAt": "2017-02-09T19:07:00.000Z",
   "description": "2016J",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "ville", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "305"
-    },
-    {
-      "player": "ville",
-      "score": "298"
-    },
-    {
-      "player": "phil",
-      "score": "235"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ken", "score": "305" },
+    { "player": "ville", "score": "298" },
+    { "player": "phil", "score": "235" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta2/7368089.json
+++ b/matches/tta2/7368089.json
@@ -4,36 +4,11 @@
   "updatedAt": "2017-03-14T11:44:00.000Z",
   "description": "2017A",
   "game": "tta2",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["aaron", "ville", "ken", "phil"],
   "results": [
-    {
-      "player": "aaron",
-      "score": "213"
-    },
-    {
-      "player": "ville",
-      "score": "205"
-    },
-    {
-      "player": "ken",
-      "score": "190"
-    },
-    {
-      "player": "phil",
-      "score": "179"
-    }
+    { "player": "aaron", "score": "213" },
+    { "player": "ville", "score": "205" },
+    { "player": "ken", "score": "190" },
+    { "player": "phil", "score": "179" }
   ]
 }

--- a/matches/tta2/7373742.json
+++ b/matches/tta2/7373742.json
@@ -4,36 +4,11 @@
   "updatedAt": "2017-04-23T05:20:00.000Z",
   "description": "2017B",
   "game": "tta2",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ville", "ken", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "186"
-    },
-    {
-      "player": "ville",
-      "score": "183"
-    },
-    {
-      "player": "ken",
-      "score": "180"
-    },
-    {
-      "player": "aaron",
-      "score": "176"
-    }
+    { "player": "phil", "score": "186" },
+    { "player": "ville", "score": "183" },
+    { "player": "ken", "score": "180" },
+    { "player": "aaron", "score": "176" }
   ]
 }

--- a/matches/tta2/7380240.json
+++ b/matches/tta2/7380240.json
@@ -4,36 +4,11 @@
   "updatedAt": "2017-06-14T09:34:00.000Z",
   "description": "2017C",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "ville", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "215"
-    },
-    {
-      "player": "aaron",
-      "score": "147"
-    },
-    {
-      "player": "ville",
-      "score": "126"
-    },
-    {
-      "player": "phil",
-      "score": "-"
-    }
+    { "player": "ken", "score": "215" },
+    { "player": "aaron", "score": "147" },
+    { "player": "ville", "score": "126" },
+    { "player": "phil", "score": "-" }
   ]
 }

--- a/matches/tta2/7388957.json
+++ b/matches/tta2/7388957.json
@@ -4,36 +4,11 @@
   "updatedAt": "2017-07-27T23:15:00.000Z",
   "description": "2017DeezNuts",
   "game": "tta2",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["phil", "ken", "ville", "aaron"],
   "results": [
-    {
-      "player": "phil",
-      "score": "237"
-    },
-    {
-      "player": "ken",
-      "score": "212"
-    },
-    {
-      "player": "ville",
-      "score": "205"
-    },
-    {
-      "player": "aaron",
-      "score": "188"
-    }
+    { "player": "phil", "score": "237" },
+    { "player": "ken", "score": "212" },
+    { "player": "ville", "score": "205" },
+    { "player": "aaron", "score": "188" }
   ]
 }

--- a/matches/tta2/7395760.json
+++ b/matches/tta2/7395760.json
@@ -4,36 +4,11 @@
   "updatedAt": "2017-08-25T14:51:00.000Z",
   "description": "2017E",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ville", "ken", "aaron", "phil"],
   "results": [
-    {
-      "player": "ville",
-      "score": "222"
-    },
-    {
-      "player": "ken",
-      "score": "213"
-    },
-    {
-      "player": "aaron",
-      "score": "186"
-    },
-    {
-      "player": "phil",
-      "score": "93"
-    }
+    { "player": "ville", "score": "222" },
+    { "player": "ken", "score": "213" },
+    { "player": "aaron", "score": "186" },
+    { "player": "phil", "score": "93" }
   ]
 }

--- a/matches/tta2/7400432.json
+++ b/matches/tta2/7400432.json
@@ -4,36 +4,11 @@
   "updatedAt": "2017-10-05T09:07:00.000Z",
   "description": "2017Fuuuuuu",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "253"
-    },
-    {
-      "player": "ken",
-      "score": "228"
-    },
-    {
-      "player": "phil",
-      "score": "218"
-    },
-    {
-      "player": "aaron",
-      "score": "188"
-    }
+    { "player": "ville", "score": "253" },
+    { "player": "ken", "score": "228" },
+    { "player": "phil", "score": "218" },
+    { "player": "aaron", "score": "188" }
   ]
 }

--- a/matches/tta2/7400516.json
+++ b/matches/tta2/7400516.json
@@ -4,36 +4,11 @@
   "updatedAt": "2017-11-15T17:33:00.000Z",
   "description": "2017G",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "179"
-    },
-    {
-      "player": "ken",
-      "score": "166"
-    },
-    {
-      "player": "phil",
-      "score": "153"
-    },
-    {
-      "player": "aaron",
-      "score": "-"
-    }
+    { "player": "ville", "score": "179" },
+    { "player": "ken", "score": "166" },
+    { "player": "phil", "score": "153" },
+    { "player": "aaron", "score": "-" }
   ]
 }

--- a/matches/tta2/7411164.json
+++ b/matches/tta2/7411164.json
@@ -4,36 +4,11 @@
   "updatedAt": "2018-02-04T09:20:00.000Z",
   "description": "2017H",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "aaron", "ville", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": "222"
-    },
-    {
-      "player": "aaron",
-      "score": "218"
-    },
-    {
-      "player": "ville",
-      "score": "201"
-    },
-    {
-      "player": "phil",
-      "score": "146"
-    }
+    { "player": "ken", "score": "222" },
+    { "player": "aaron", "score": "218" },
+    { "player": "ville", "score": "201" },
+    { "player": "phil", "score": "146" }
   ]
 }

--- a/matches/tta2/7419451.json
+++ b/matches/tta2/7419451.json
@@ -4,36 +4,11 @@
   "updatedAt": "2018-04-19T12:27:00.000Z",
   "description": "2018A",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "238"
-    },
-    {
-      "player": "ken",
-      "score": "206"
-    },
-    {
-      "player": "phil",
-      "score": "180"
-    },
-    {
-      "player": "aaron",
-      "score": "163"
-    }
+    { "player": "ville", "score": "238" },
+    { "player": "ken", "score": "206" },
+    { "player": "phil", "score": "180" },
+    { "player": "aaron", "score": "163" }
   ]
 }

--- a/matches/tta2/7426549.json
+++ b/matches/tta2/7426549.json
@@ -4,36 +4,11 @@
   "updatedAt": "2018-07-04T06:46:00.000Z",
   "description": "2018B",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "ville"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ken", "ville", "phil", "aaron"],
   "results": [
-    {
-      "player": "ken",
-      "score": "186"
-    },
-    {
-      "player": "ville",
-      "score": "159"
-    },
-    {
-      "player": "phil",
-      "score": "134"
-    },
-    {
-      "player": "aaron",
-      "score": "128"
-    }
+    { "player": "ken", "score": "186" },
+    { "player": "ville", "score": "159" },
+    { "player": "phil", "score": "134" },
+    { "player": "aaron", "score": "128" }
   ]
 }

--- a/matches/tta2/7432906.json
+++ b/matches/tta2/7432906.json
@@ -4,36 +4,11 @@
   "updatedAt": "2018-10-22T12:52:00.000Z",
   "description": "2018C",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ville"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["ville", "ken", "phil", "aaron"],
   "results": [
-    {
-      "player": "ville",
-      "score": "193"
-    },
-    {
-      "player": "ken",
-      "score": "171"
-    },
-    {
-      "player": "phil",
-      "score": "170"
-    },
-    {
-      "player": "aaron",
-      "score": "164"
-    }
+    { "player": "ville", "score": "193" },
+    { "player": "ken", "score": "171" },
+    { "player": "phil", "score": "170" },
+    { "player": "aaron", "score": "164" }
   ]
 }

--- a/matches/tta2/7474698.json
+++ b/matches/tta2/7474698.json
@@ -4,36 +4,11 @@
   "updatedAt": "2020-04-28T17:59:00.000Z",
   "description": "FUCK TERRA MYSTICA",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "matt"
-    },
-    {
-      "id": "adam"
-    }
-  ],
+  "players": ["ken", "phil", "matt", "adam"],
   "results": [
-    {
-      "player": "ken",
-      "score": "265"
-    },
-    {
-      "player": "phil",
-      "score": "257"
-    },
-    {
-      "player": "matt",
-      "score": "210"
-    },
-    {
-      "player": "adam",
-      "score": "208"
-    }
+    { "player": "ken", "score": "265" },
+    { "player": "phil", "score": "257" },
+    { "player": "matt", "score": "210" },
+    { "player": "adam", "score": "208" }
   ]
 }

--- a/matches/tta2/Combat II.json
+++ b/matches/tta2/Combat II.json
@@ -5,36 +5,11 @@
   "location": "TTA App",
   "description": "Combat II",
   "game": "tta2",
-  "players": [
-    {
-      "id": "adam"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    }
-  ],
+  "players": ["adam", "aaron", "phil", "ken"],
   "results": [
-    {
-      "player": "adam",
-      "score": 179
-    },
-    {
-      "player": "ken",
-      "score": 161
-    },
-    {
-      "player": "phil",
-      "score": 153
-    },
-    {
-      "player": "aaron",
-      "score": 63
-    }
+    { "player": "adam", "score": 179 },
+    { "player": "ken", "score": 161 },
+    { "player": "phil", "score": 153 },
+    { "player": "aaron", "score": 63 }
   ]
 }

--- a/matches/tta2/Combat III.json
+++ b/matches/tta2/Combat III.json
@@ -5,36 +5,11 @@
   "location": "TTA App",
   "description": "Combat III",
   "game": "tta2",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "matt"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "adam"
-    }
-  ],
+  "players": ["phil", "matt", "ken", "adam"],
   "results": [
-    {
-      "player": "ken",
-      "score": 265
-    },
-    {
-      "player": "adam",
-      "score": 224
-    },
-    {
-      "player": "matt",
-      "score": 204
-    },
-    {
-      "player": "phil",
-      "score": 200
-    }
+    { "player": "ken", "score": 265 },
+    { "player": "adam", "score": 224 },
+    { "player": "matt", "score": 204 },
+    { "player": "phil", "score": 200 }
   ]
 }

--- a/matches/tta2/Combat IV.json
+++ b/matches/tta2/Combat IV.json
@@ -5,36 +5,11 @@
   "location": "TTA App",
   "description": "Combat IV",
   "game": "tta2",
-  "players": [
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "matt"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["aaron", "ken", "matt", "phil"],
   "results": [
-    {
-      "player": "aaron",
-      "score": 279
-    },
-    {
-      "player": "ken",
-      "score": 258
-    },
-    {
-      "player": "phil",
-      "score": 258
-    },
-    {
-      "player": "matt",
-      "score": 208
-    }
+    { "player": "aaron", "score": 279 },
+    { "player": "ken", "score": 258 },
+    { "player": "phil", "score": 258 },
+    { "player": "matt", "score": 208 }
   ]
 }

--- a/matches/tta2/My Victry - 20200610.json
+++ b/matches/tta2/My Victry - 20200610.json
@@ -5,36 +5,11 @@
   "location": "TTA App",
   "description": "My Victry",
   "game": "tta2",
-  "players": [
-    {
-      "id": "jenn"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "adam"
-    },
-    {
-      "id": "aaron"
-    }
-  ],
+  "players": ["jenn", "ken", "adam", "aaron"],
   "results": [
-    {
-      "player": "aaron",
-      "score": 114
-    },
-    {
-      "player": "ken",
-      "score": 106
-    },
-    {
-      "player": "adam",
-      "score": 103
-    },
-    {
-      "player": "jenn",
-      "score": 61
-    }
+    { "player": "aaron", "score": 114 },
+    { "player": "ken", "score": 106 },
+    { "player": "adam", "score": 103 },
+    { "player": "jenn", "score": 61 }
   ]
 }

--- a/matches/tta2/Now That's What I Call Combat V.json
+++ b/matches/tta2/Now That's What I Call Combat V.json
@@ -5,36 +5,11 @@
   "location": "TTA App",
   "description": "Now That's What I Call Combat V",
   "game": "tta2",
-  "players": [
-    {
-      "id": "matt"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "aaron"
-    },
-    {
-      "id": "adam"
-    }
-  ],
+  "players": ["matt", "ken", "aaron", "adam"],
   "results": [
-    {
-      "player": "adam",
-      "score": 299
-    },
-    {
-      "player": "aaron",
-      "score": 274
-    },
-    {
-      "player": "ken",
-      "score": 266
-    },
-    {
-      "player": "matt",
-      "score": 0
-    }
+    { "player": "adam", "score": 299 },
+    { "player": "aaron", "score": 274 },
+    { "player": "ken", "score": 266 },
+    { "player": "matt", "score": 0 }
   ]
 }

--- a/matches/tta2/The Learning Channel.json
+++ b/matches/tta2/The Learning Channel.json
@@ -5,29 +5,10 @@
   "location": "TTA App",
   "description": "The Learning Channel",
   "game": "tta2",
-  "players": [
-    {
-      "id": "jenn"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "adam"
-    }
-  ],
+  "players": ["jenn", "ken", "adam"],
   "results": [
-    {
-      "player": "adam",
-      "score": 192
-    },
-    {
-      "player": "ken",
-      "score": 189
-    },
-    {
-      "player": "jenn",
-      "score": 131
-    }
+    { "player": "adam", "score": 192 },
+    { "player": "ken", "score": 189 },
+    { "player": "jenn", "score": 131 }
   ]
 }

--- a/matches/tta2/The Wobbly Eifel Tower of Life.json
+++ b/matches/tta2/The Wobbly Eifel Tower of Life.json
@@ -5,29 +5,10 @@
   "location": "TTA App",
   "description": "The Wobbly Eifel Tower of Life",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "adam"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "adam", "phil"],
   "results": [
-    {
-      "player": "ken",
-      "score": 194
-    },
-    {
-      "player": "phil",
-      "score": 179
-    },
-    {
-      "player": "adam",
-      "score": 158
-    }
+    { "player": "ken", "score": 194 },
+    { "player": "phil", "score": 179 },
+    { "player": "adam", "score": 158 }
   ]
 }

--- a/matches/tta2/The Wobbly H of Life.json
+++ b/matches/tta2/The Wobbly H of Life.json
@@ -5,29 +5,10 @@
   "location": "TTA App",
   "description": "The Wobbly H of Life",
   "game": "tta2",
-  "players": [
-    {
-      "id": "phil"
-    },
-    {
-      "id": "ken"
-    },
-    {
-      "id": "adam"
-    }
-  ],
+  "players": ["phil", "ken", "adam"],
   "results": [
-    {
-      "player": "ken",
-      "score": 180
-    },
-    {
-      "player": "phil",
-      "score": 169
-    },
-    {
-      "player": "adam",
-      "score": 138
-    }
+    { "player": "ken", "score": 180 },
+    { "player": "phil", "score": 169 },
+    { "player": "adam", "score": 138 }
   ]
 }

--- a/matches/tta2/Wobbly Eiffel Tower Defense.json
+++ b/matches/tta2/Wobbly Eiffel Tower Defense.json
@@ -5,36 +5,11 @@
   "location": "TTA App",
   "description": "Wobbly Eiffel Tower Defense",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "mattkahn"
-    },
-    {
-      "id": "adam"
-    },
-    {
-      "id": "phil"
-    }
-  ],
+  "players": ["ken", "mattkahn", "adam", "phil"],
   "results": [
-    {
-      "player": "mattkahn",
-      "score": 166
-    },
-    {
-      "player": "ken",
-      "score": 148
-    },
-    {
-      "player": "phil",
-      "score": 133
-    },
-    {
-      "player": "adam",
-      "score": 0
-    }
+    { "player": "mattkahn", "score": 166 },
+    { "player": "ken", "score": 148 },
+    { "player": "phil", "score": 133 },
+    { "player": "adam", "score": 0 }
   ]
 }

--- a/matches/tta2/Wobbly Eiffel Tower goes Limp, The.json
+++ b/matches/tta2/Wobbly Eiffel Tower goes Limp, The.json
@@ -5,29 +5,10 @@
   "location": "TTA App",
   "description": "Wobbly Eiffel Tower goes Limp, The",
   "game": "tta2",
-  "players": [
-    {
-      "id": "ken"
-    },
-    {
-      "id": "phil"
-    },
-    {
-      "id": "adam"
-    }
-  ],
+  "players": ["ken", "phil", "adam"],
   "results": [
-    {
-      "player": "phil",
-      "score": 198
-    },
-    {
-      "player": "ken",
-      "score": 179
-    },
-    {
-      "player": "adam",
-      "score": 0
-    }
+    { "player": "phil", "score": 198 },
+    { "player": "ken", "score": 179 },
+    { "player": "adam", "score": 0 }
   ]
 }

--- a/matches/ttr/2020-04-06.json
+++ b/matches/ttr/2020-04-06.json
@@ -4,12 +4,7 @@
   "updatedAt": "2020-04-06T00:00:00.000Z",
   "description": "A game played on 2020-04-06 over Zoom",
   "game": "ttr",
-  "players": [
-    { "id": "koop" },
-    { "id": "jess" },
-    { "id": "katie" },
-    { "id": "phil" }
-  ],
+  "players": ["koop", "jess", "katie", "phil"],
   "results": [
     { "player": "jess", "score": 121 },
     { "player": "phil", "score": 111 },

--- a/matches/ttr/2020-04-13A.json
+++ b/matches/ttr/2020-04-13A.json
@@ -4,13 +4,7 @@
   "updatedAt": "2020-04-13T00:00:00.000Z",
   "description": "A game played on 2020-04-13 over Zoom",
   "game": "ttr",
-  "players": [
-    { "id": "jelle" },
-    { "id": "jennt" },
-    { "id": "katie" },
-    { "id": "jess" },
-    { "id": "phil" }
-  ],
+  "players": ["jelle", "jennt", "katie", "jess", "phil"],
   "results": [
     { "player": "jess", "score": 123 },
     { "player": "phil", "score": 122 },

--- a/matches/ttr/2020-04-13B.json
+++ b/matches/ttr/2020-04-13B.json
@@ -4,13 +4,7 @@
   "updatedAt": "2020-04-13T00:00:00.001Z",
   "description": "A game played on 2020-04-13 over Zoom",
   "game": "ttr",
-  "players": [
-    { "id": "jelle" },
-    { "id": "jennt" },
-    { "id": "katie" },
-    { "id": "jess" },
-    { "id": "phil" }
-  ],
+  "players": ["jelle", "jennt", "katie", "jess", "phil"],
   "results": [
     { "player": "jess", "score": 133 },
     { "player": "jelle", "score": 132 },

--- a/matches/ttr/2020-04-20.json
+++ b/matches/ttr/2020-04-20.json
@@ -4,12 +4,7 @@
   "updatedAt": "2020-04-20T00:00:00.000Z",
   "description": "A game played on 2020-04-20 over Zoom",
   "game": "ttr",
-  "players": [
-    { "id": "jelle" },
-    { "id": "katie" },
-    { "id": "jess" },
-    { "id": "phil" }
-  ],
+  "players": ["jelle", "katie", "jess", "phil"],
   "results": [
     { "player": "jelle", "score": 132 },
     { "player": "phil", "score": 129 },

--- a/matches/ttr/2020-04-21.json
+++ b/matches/ttr/2020-04-21.json
@@ -5,7 +5,7 @@
   "description": "Game played over the board where Phil made a roadblock down the Mississippi",
   "location": "Steiner",
   "game": "ttr",
-  "players": [{ "id": "jess" }, { "id": "phil" }],
+  "players": ["jess", "phil"],
   "results": [
     { "player": "phil", "score": 107 },
     { "player": "jess", "score": 13 }

--- a/matches/ttr/2020-04-26A.json
+++ b/matches/ttr/2020-04-26A.json
@@ -4,13 +4,7 @@
   "updatedAt": "2020-04-26T00:00:00.000Z",
   "description": "A game played on 2020-04-26 over Zoom",
   "game": "ttr",
-  "players": [
-    { "id": "koop" },
-    { "id": "jelle" },
-    { "id": "jess" },
-    { "id": "katie" },
-    { "id": "phil" }
-  ],
+  "players": ["koop", "jelle", "jess", "katie", "phil"],
   "results": [
     { "player": "jess", "score": 142 },
     { "player": "katie", "score": 130 },

--- a/matches/ttr/2020-04-26B.json
+++ b/matches/ttr/2020-04-26B.json
@@ -4,13 +4,7 @@
   "updatedAt": "2020-04-26T00:00:00.001Z",
   "description": "A game played on 2020-04-26 over Zoom",
   "game": "ttr",
-  "players": [
-    { "id": "koop" },
-    { "id": "jelle" },
-    { "id": "jess" },
-    { "id": "katie" },
-    { "id": "phil" }
-  ],
+  "players": ["koop", "jelle", "jess", "katie", "phil"],
   "results": [
     { "player": "jelle", "score": 143 },
     { "player": "koop", "score": 135 },

--- a/matches/ttr/2020-05-01.json
+++ b/matches/ttr/2020-05-01.json
@@ -4,13 +4,7 @@
   "updatedAt": "2020-05-01T00:00:00.000Z",
   "description": "A game played on 2020-05-01 over Zoom",
   "game": "ttr",
-  "players": [
-    { "id": "billy" },
-    { "id": "jelle" },
-    { "id": "jess" },
-    { "id": "katie" },
-    { "id": "phil" }
-  ],
+  "players": ["billy", "jelle", "jess", "katie", "phil"],
   "results": [
     { "player": "jelle", "score": 52 },
     { "player": "billy", "score": 82 },

--- a/matches/ttr/2020-05-18A.json
+++ b/matches/ttr/2020-05-18A.json
@@ -4,13 +4,7 @@
   "updatedAt": "2020-05-18T00:00:00.000Z",
   "description": "A game played on 2020-05-01 over Zoom",
   "game": "ttr",
-  "players": [
-    { "id": "billy" },
-    { "id": "jelle" },
-    { "id": "jess" },
-    { "id": "katie" },
-    { "id": "phil" }
-  ],
+  "players": ["billy", "jelle", "jess", "katie", "phil"],
   "results": [
     { "player": "phil", "score": 152 },
     { "player": "jess", "score": 103 },

--- a/matches/ttr/2020-05-18B.json
+++ b/matches/ttr/2020-05-18B.json
@@ -4,13 +4,7 @@
   "updatedAt": "2020-05-18T00:00:00.001Z",
   "description": "A game played on 2020-05-01 over Zoom",
   "game": "ttr",
-  "players": [
-    { "id": "koop" },
-    { "id": "jelle" },
-    { "id": "jess" },
-    { "id": "katie" },
-    { "id": "phil" }
-  ],
+  "players": ["koop", "jelle", "jess", "katie", "phil"],
   "results": [
     { "player": "katie", "score": 127 },
     { "player": "koop", "score": 111 },

--- a/matches/ttr/2020-05-21A.json
+++ b/matches/ttr/2020-05-21A.json
@@ -4,7 +4,7 @@
   "updatedAt": "2020-05-21T00:00:00.00Z",
   "description": "A game played on 2020-05-21",
   "game": "ttr",
-  "players": [{ "id": "billy" }, { "id": "jelle" }],
+  "players": ["billy", "jelle"],
   "results": [
     { "player": "jelle", "score": 158 },
     { "player": "billy", "score": 112 }

--- a/matches/ttr/2020-05-21B.json
+++ b/matches/ttr/2020-05-21B.json
@@ -4,7 +4,7 @@
   "updatedAt": "2020-05-21T00:00:00.01Z",
   "description": "A game played on 2020-05-21",
   "game": "ttr",
-  "players": [{ "id": "billy" }, { "id": "jelle" }],
+  "players": ["billy", "jelle"],
   "results": [
     { "player": "jelle", "score": 146 },
     { "player": "billy", "score": 141 }

--- a/matches/ttr/2020-05-22A.json
+++ b/matches/ttr/2020-05-22A.json
@@ -4,7 +4,7 @@
   "updatedAt": "2020-05-22T00:00:00.00Z",
   "description": "A game played on 2020-05-22",
   "game": "ttr",
-  "players": [{ "id": "billy" }, { "id": "jelle" }],
+  "players": ["billy", "jelle"],
   "results": [
     { "player": "jelle", "score": 136 },
     { "player": "billy", "score": 103 }

--- a/matches/ttr/2020-05-22B.json
+++ b/matches/ttr/2020-05-22B.json
@@ -4,7 +4,7 @@
   "updatedAt": "2020-05-22T00:00:01.00Z",
   "description": "A game played on 2020-05-22",
   "game": "ttr",
-  "players": [{ "id": "billy" }, { "id": "jelle" }, { "id": "ryan" }],
+  "players": ["billy", "jelle", "ryan"],
   "results": [
     { "player": "billy", "score": 129 },
     { "player": "ryan", "score": 114 },

--- a/matches/ttr/2020-05-22C.json
+++ b/matches/ttr/2020-05-22C.json
@@ -4,7 +4,7 @@
   "updatedAt": "2020-05-22T00:00:02.00Z",
   "description": "A game played on 2020-05-22",
   "game": "ttr",
-  "players": [{ "id": "billy" }, { "id": "jelle" }],
+  "players": ["billy", "jelle"],
   "results": [
     { "player": "billy", "score": 145 },
     { "player": "jelle", "score": 123 }


### PR DESCRIPTION
ran the following script to cleanup the `players` property on all matches.

```js
const fs = require('fs')
const glob = require('glob').sync
const { map } = require('ramda')

map(
  (file) => {
    const rawData = fs.readFileSync(file)
    const jsonData = JSON.parse(rawData)
    jsonData.players = map((p) => p.id, jsonData.players)
    const newData = JSON.stringify({
      ...jsonData
      players: map((p) => p.id, jsonData.players)
    })
    fs.writeFileSync(file, newData)
  },
  glob('matches/**/*.json', { ignore: ['**/match.schema.json'] })
)
```